### PR TITLE
remove path with [lang] from exportedPath

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -129,10 +129,17 @@ function withI18nTagPlugin(nextConfig = {}, composePlugins = {}) {
     if (phase === PHASE_EXPORT) {
       Object.assign(newConfig, {
         exportTrailingSlash: true,
-        exportPathMap: defaultPathMap => ({
-          ...defaultPathMap,
-          ...localizedPathMaps(),
-        }),
+        exportPathMap: defaultPathMap => {
+          Object.keys(defaultPathMap).forEach(key => {
+            if (key.indexOf('/[lang]') > -1) {
+              delete defaultPathMap[key]
+            }
+          })
+          return {
+            ...defaultPathMap,
+            ...localizedPathMaps(),
+          }
+        },
       })
     }
 


### PR DESCRIPTION
This commit avoid files to be generated under the [lang] path during a static export making the build faster and cleaner.